### PR TITLE
Add option to define a connection timeout

### DIFF
--- a/jsmpp-examples/src/main/java/org/jsmpp/examples/session/connection/socket/TrustStoreSSLSocketConnectionFactory.java
+++ b/jsmpp-examples/src/main/java/org/jsmpp/examples/session/connection/socket/TrustStoreSSLSocketConnectionFactory.java
@@ -57,4 +57,9 @@ public class TrustStoreSSLSocketConnectionFactory implements ConnectionFactory {
       throws IOException {
     return new SocketConnection(sslSocketFactory.createSocket(host, port));
   }
+
+  @Override
+  public Connection createConnection(String host, int port, int timeout) throws IOException {
+    return new SocketConnection(sslSocketFactory.createSocket(host, port));
+  }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
@@ -64,6 +64,7 @@ public abstract class AbstractSession implements Session, Closeable {
 
     private final String sessionId = generateSessionId();
     private int enquireLinkTimer = 60000;
+    private int connectionTimeout = -1;
     private long transactionTimer = 2000;
 
     protected EnquireLinkSender enquireLinkSender;
@@ -118,6 +119,16 @@ public abstract class AbstractSession implements Session, Closeable {
     @Override
     public int getEnquireLinkTimer() {
         return enquireLinkTimer;
+    }
+
+    @Override
+    public void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    @Override
+    public int getConnectionTimeout() {
+        return connectionTimeout;
     }
 
     @Override

--- a/jsmpp/src/main/java/org/jsmpp/session/Session.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/Session.java
@@ -105,6 +105,8 @@ public interface Session {
     InterfaceVersion getInterfaceVersion();
     void setEnquireLinkTimer(int enquireLinkTimer);
     int getEnquireLinkTimer();
+    void setConnectionTimeout(int connectionTimeout);
+    int getConnectionTimeout();
     void setTransactionTimer(long transactionTimer);
     long getTransactionTimer();
     SessionState getSessionState();

--- a/jsmpp/src/main/java/org/jsmpp/session/connection/ConnectionFactory.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/connection/ConnectionFactory.java
@@ -22,4 +22,5 @@ import java.io.IOException;
  */
 public interface ConnectionFactory {
     Connection createConnection(String host, int port) throws IOException;
+    Connection createConnection(String host, int port, int timeout) throws IOException;
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/connection/socket/NoTrustSSLSocketConnectionFactory.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/connection/socket/NoTrustSSLSocketConnectionFactory.java
@@ -65,4 +65,9 @@ public class NoTrustSSLSocketConnectionFactory implements ConnectionFactory {
     return new SocketConnection(socketFactory.createSocket(host, port));
   }
 
+  @Override
+  public Connection createConnection(String host, int port, int timeout) throws IOException {
+    return this.createConnection(host, port);
+  }
+
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/connection/socket/SSLSocketConnectionFactory.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/connection/socket/SSLSocketConnectionFactory.java
@@ -47,4 +47,9 @@ public class SSLSocketConnectionFactory implements ConnectionFactory {
       throws IOException {
     return new SocketConnection(socketFactory.createSocket(host, port));
   }
+
+  @Override
+  public Connection createConnection(String host, int port, int timeout) throws IOException {
+    return new SocketConnection(socketFactory.createSocket(host, port));
+  }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/connection/socket/SocketConnectionFactory.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/connection/socket/SocketConnectionFactory.java
@@ -15,6 +15,7 @@
 package org.jsmpp.session.connection.socket;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 
 import org.jsmpp.session.connection.Connection;
@@ -38,5 +39,12 @@ public class SocketConnectionFactory implements ConnectionFactory {
     public Connection createConnection(String host, int port)
             throws IOException {
         return new SocketConnection(new Socket(host, port));
+    }
+
+    public Connection createConnection(String host, int port, int timeout) throws IOException {
+        Socket socket = new Socket();
+        InetSocketAddress endpoint = new InetSocketAddress(host, port);
+        socket.connect(endpoint, timeout);
+        return new SocketConnection(socket);
     }
 }


### PR DESCRIPTION
## Purpose

Add option to define a connection timeout. One of the following configs can be used,

1. When we use setEnquireLinkTimer(timeout), the timeout will be used as the connection timeout first and the remaining value will be set as the socket timeout.

2. When we use both setEnquireLinkTimer(timeout) and setConnectionTimeout(time), the EnquireLinkTimer will be used as the socket timeout.

Fixes: https://github.com/wso2/micro-integrator/issues/3059