### PR TITLE
Update the apache felix version

### DIFF
--- a/jsmpp/pom.xml
+++ b/jsmpp/pom.xml
@@ -59,6 +59,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <version>${maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <slf4j.version>1.7.36</slf4j.version>
         <junit.version>4.13.2</junit.version>
         <testng.version>6.14.3</testng.version>
+        <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
         <telecom-charsets.version>1.0.1</telecom-charsets.version>
         <commons-codec.version>1.15</commons-codec.version>
         <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>


### PR DESCRIPTION
This PR is to fix the build failure with the error 
`[ERROR] Failed to execute goal org.apache.felix:maven-bundle-plugin:6.0.0:bundle (default-bundle) on project jsmpp: Execution default-bundle of goal org.apache.felix:maven-bundle-plugin:6.0.0:bundle failed: An API incompatibility was encountered while executing org.apache.felix:maven-bundle-plugin:6.0.0:bundle: java.lang.UnsupportedClassVersionError: aQute/bnd/osgi/Resource has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0`